### PR TITLE
refactor(examples): use basic `Client` for downloads

### DIFF
--- a/examples/download.rs
+++ b/examples/download.rs
@@ -2,10 +2,7 @@ use webtoon::platform::webtoons::{errors::Error, Client, Type};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Error> {
-    let client = match std::env::var("WEBTOON_SESSION") {
-        Ok(session) if !session.is_empty() => Client::with_session(&session),
-        _ => Client::new(),
-    };
+    let client = Client::new();
 
     let Some(webtoon) = client.webtoon(843910, Type::Canvas).await? else {
         panic!("No webtoon of given id and type exits");


### PR DESCRIPTION
There is no need for a session in this example