### PR TITLE
feat(creator): add check for disabled profile page

### DIFF
--- a/src/platform/webtoons/creator/mod.rs
+++ b/src/platform/webtoons/creator/mod.rs
@@ -106,6 +106,10 @@ pub(super) async fn page(
         return Ok(None);
     }
 
+    if response.status() == 400 {
+        return Err(CreatorError::DisabledByCreator);
+    }
+
     let document = response.text().await?;
 
     let html = Html::parse_document(&document);

--- a/src/platform/webtoons/errors.rs
+++ b/src/platform/webtoons/errors.rs
@@ -82,6 +82,8 @@ pub enum CreatorError {
     UnsupportedLanguage,
     #[error(transparent)]
     Unexpected(#[from] anyhow::Error),
+    #[error("Profile page exists, but was disabled by creator")]
+    DisabledByCreator,
 }
 
 impl From<reqwest::Error> for CreatorError {


### PR DESCRIPTION
A profile can be disabled by a creator. This case is different from a profile not existing, and thus being `None`. To handle this difference, returning an error here describing why the page cannot be processed and allowing application code to handle that case makes the most sense.