### PR TITLE
refactor!: move `rss` and `download` behind feature flags

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features
   test-with-session:
     runs-on: ubuntu-latest
     steps:
@@ -22,16 +22,16 @@ jobs:
     - name: Run tests
       env:
         WEBTOON_SESSION: ${{ secrets.WEBTOON_SESSION }}
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features
   fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Run format check
-      run: cargo fmt --check
+      run: cargo fmt --check --all-features
   clippy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Run clippy check
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --all-features -- -D warnings

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features
   test-with-session:
     runs-on: ubuntu-latest
     steps:
@@ -21,4 +21,4 @@ jobs:
     - name: Run tests
       env:
         WEBTOON_SESSION: ${{ secrets.WEBTOON_SESSION }}
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,16 @@ html-escape = "0.2"
 url = "2"
 # used when the session needs to be sent in a url
 urlencoding = "2"
-rss = "2"
-image = "0.25"
+rss = { version = "2", optional = true }
+image = { version = "0.25", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1"
+
+[features]
+default = []
+rss = ["dep:rss"]
+download = ["dep:image"]
 
 [[example]]
 name = "search"
@@ -55,6 +60,7 @@ path = "examples/webtoon.rs"
 [[example]]
 name = "rss"
 path = "examples/rss.rs"
+required-features = ["rss"]
 
 [[example]]
 name = "episodes"
@@ -67,3 +73,4 @@ path = "examples/posts.rs"
 [[example]]
 name = "download"
 path = "examples/download.rs"
+required-features = ["download"]

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ async fn main() -> Result<(), Error> {
 ```
 
 For more examples, check out the [`examples`](https://github.com/Webtoon-Studio/webtoon/tree/main/examples) folder.
+
+## Features
+
+- `rss`: Enables the ability to get the RSS feed data for a webtoon.
+- `download`: Enables the ability to download an episodes panels.

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -1,5 +1,6 @@
 use webtoon::platform::webtoons::{errors::Error, Client, Type};
 
+// NOTE: To run: `cargo run --example download --features download`
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Error> {
     let client = match std::env::var("WEBTOON_SESSION") {

--- a/examples/rss.rs
+++ b/examples/rss.rs
@@ -1,5 +1,6 @@
 use webtoon::platform::webtoons::{errors::Error, Client, Type};
 
+// NOTE: To run: `cargo run --example rss --features rss`
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Error> {
     let client = Client::new();

--- a/src/platform/webtoons/client.rs
+++ b/src/platform/webtoons/client.rs
@@ -1088,6 +1088,7 @@ impl Client {
         Ok(response)
     }
 
+    #[cfg(feature = "rss")]
     pub(super) async fn get_rss_for_webtoon(
         &self,
         webtoon: &Webtoon,

--- a/src/platform/webtoons/errors.rs
+++ b/src/platform/webtoons/errors.rs
@@ -27,6 +27,7 @@ pub enum Error {
     #[error(transparent)]
     PosterError(#[from] PosterError),
     #[error(transparent)]
+    #[cfg(feature = "download")]
     DownloadError(#[from] DownloadError),
 }
 
@@ -218,6 +219,7 @@ impl From<reqwest::Error> for SearchError {
     }
 }
 
+#[cfg(feature = "download")]
 #[allow(missing_docs)]
 #[non_exhaustive]
 #[derive(Debug, Error)]
@@ -230,6 +232,7 @@ pub enum DownloadError {
     Unexpected(#[from] anyhow::Error),
 }
 
+#[cfg(feature = "download")]
 impl From<reqwest::Error> for DownloadError {
     fn from(error: reqwest::Error) -> Self {
         Self::ClientError(ClientError::from(error))

--- a/src/platform/webtoons/webtoon/episode.rs
+++ b/src/platform/webtoons/webtoon/episode.rs
@@ -3,7 +3,9 @@
 mod page;
 pub mod posts;
 
-pub use page::panel::{Panel, Panels};
+pub use page::panels::Panel;
+#[cfg(feature = "download")]
+pub use page::panels::Panels;
 
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -16,7 +18,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::sync::Arc;
 use std::{hash::Hash, str::FromStr};
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::Mutex;
 
 use self::page::Page;
 use self::posts::Posts;
@@ -1121,7 +1123,10 @@ impl Episode {
     /// Will download the panels of episode.
     ///
     /// This returns a [`Panels`] which offers ways to save to disk.
+    #[cfg(feature = "download")]
     pub async fn download(&self) -> Result<Panels, EpisodeError> {
+        use tokio::sync::Semaphore;
+
         let mut page = self.page.lock().await;
         if page.is_none() {
             *page = Some(self.scrape().await?);

--- a/src/platform/webtoons/webtoon/episode/page.rs
+++ b/src/platform/webtoons/webtoon/episode/page.rs
@@ -1,10 +1,11 @@
-pub(super) mod panel;
+pub(super) mod panels;
 
 use anyhow::Context;
 use scraper::{Html, Selector};
 use url::Url;
 
-use self::panel::{Panel, Panels};
+use self::panels::Panel;
+
 use super::EpisodeError;
 
 #[derive(Debug, Clone)]
@@ -23,7 +24,7 @@ impl Page {
             thumbnail: thumbnail(html, episode).context("Episode thumbnail failed to be parsed")?,
             length: length(html).context("Episode length failed to be parsed")?,
             note: note(html).context("Episode creator note failed to be parsed")?,
-            panels: Panels::from_html(html, episode)
+            panels: panels::from_html(html, episode)
                 .context("Episode panel urls failed to be parsed")?,
         })
     }

--- a/src/platform/webtoons/webtoon/mod.rs
+++ b/src/platform/webtoons/webtoon/mod.rs
@@ -3,14 +3,17 @@
 mod dashboard;
 pub mod episode;
 mod page;
-pub mod rss;
 
 use anyhow::Context;
 use core::fmt;
-use rss::Rss;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+#[cfg(feature = "rss")]
+pub mod rss;
+#[cfg(feature = "rss")]
+use rss::Rss;
 
 use self::{
     episode::{posts::Posts, Episode, Episodes},
@@ -762,6 +765,7 @@ impl Webtoon {
     ///
     /// - `WebtoonError::ClientError`: If there is an issue with the client while retrieving the RSS feed.
     /// - `WebtoonError::Unexpected`: If an unexpected error occurs during the process.
+    #[cfg(feature = "rss")]
     pub async fn rss(&self) -> Result<Rss, WebtoonError> {
         rss::feed(self).await
     }


### PR DESCRIPTION
This can save on build time and dependencies when not using them. Mainly, this prevents the `rss` and `image` crate from being build by default.