### PR TITLE
docs: add `docs.rs` flag for feature annotations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
     clippy::cargo_common_metadata,
     clippy::multiple_crate_versions
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 mod stdx;
 


### PR DESCRIPTION
[`doc_auto_cfg`:Automatically generate `#[doc(cfg)]`](https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg)

-   Tracking issue:
[#43781](https://github.com/rust-lang/rust/issues/43781)

`doc_auto_cfg` is an extension to the `#[doc(cfg)]` feature. With it, you don't need to add `#[doc(cfg(...)]` anymore unless you want to override the default behaviour.