### PR TITLE
perf(replies): add early return when replies are zero

### DIFF
--- a/src/platform/webtoons/client.rs
+++ b/src/platform/webtoons/client.rs
@@ -1300,13 +1300,15 @@ impl Client {
 
         let url =format!("https://www.webtoons.com/p/api/community/v2/reaction/post_like/channel/{page_id}/content/{}/emotion/count", post.id) ;
 
-        self.http
+        let response = self
+            .http
             .get(url)
             .header("Service-Ticket-Id", "epicom")
             .header("Cookie", format!("NEO_SES={session}"))
             .send()
-            .await
-            .map_err(|err| ClientError::Unexpected(err.into()))
+            .await?;
+
+        Ok(response)
     }
 
     pub(super) async fn get_replies_for_post(

--- a/src/platform/webtoons/webtoon/episode/posts.rs
+++ b/src/platform/webtoons/webtoon/episode/posts.rs
@@ -1279,6 +1279,10 @@ impl Replies for u32 {
 impl Sealed for Posts {}
 impl Replies for Posts {
     async fn replies(post: &Post) -> Result<Self, PostError> {
+        // No need to make a network request when there ar no replies to fetch.
+        if post.replies == 0 {
+            return Ok(Posts { posts: Vec::new() });
+        }
         #[allow(
             clippy::mutable_key_type,
             reason = "`Post` has a `Client` that has interior mutability, but the `Hash` implementation only uses an id: Id, which has no mutability"


### PR DESCRIPTION
This prevents a network request, which when done on every post, even those with no known replies, can lead to a `429 Too Many Requests` response, which would cause a panic elsewhere in the code.