### PR TITLE
fix(posts): add support for `Super Like` post `section`

### DIFF
--- a/examples/posts.rs
+++ b/examples/posts.rs
@@ -12,12 +12,12 @@ async fn main() -> Result<(), Error> {
         _ => Client::new(),
     };
 
-    let Some(webtoon) = client.webtoon(843910, Type::Canvas).await? else {
+    let Some(webtoon) = client.webtoon(805407, Type::Canvas).await? else {
         panic!("No webtoon of given id and type exits");
     };
 
     let episode = webtoon
-        .episode(1)
+        .episode(2)
         .await?
         .expect("No episode for given number");
 

--- a/src/platform/webtoons/client/posts.rs
+++ b/src/platform/webtoons/client/posts.rs
@@ -166,6 +166,11 @@ pub enum Section {
         section_id: String,
         data: ContentMetaData,
     },
+    #[serde(rename = "SUPER_LIKE")]
+    SuperLike {
+        section_id: String,
+        data: SuperLikeData,
+    },
 }
 
 #[allow(unused)]
@@ -210,6 +215,15 @@ pub struct ContentInfo {
 #[serde(rename_all = "camelCase")]
 pub struct Extra {
     pub episode_list_path: String,
+}
+
+#[allow(unused, clippy::struct_field_names)]
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SuperLikeData {
+    pub super_like_count: u32,
+    pub super_like_price: u32,
+    pub super_like_received_at: i64,
 }
 
 #[allow(dead_code)]

--- a/src/platform/webtoons/webtoon/episode/posts.rs
+++ b/src/platform/webtoons/webtoon/episode/posts.rs
@@ -733,6 +733,7 @@ impl TryFrom<(&Episode, webtoons::client::posts::Post)> for Post {
         let is_spoiler = post.settings.spoiler_filter == "ON";
 
         // Only Webtoon flare can have multiple.
+        // Super likes might be able to exist along with other flare?
         let flare = if post.section_group.sections.len() > 1 {
             let mut webtoons = Vec::new();
             for section in post.section_group.sections {
@@ -743,6 +744,9 @@ impl TryFrom<(&Episode, webtoons::client::posts::Post)> for Post {
                     );
                     let webtoon = episode.webtoon.client.webtoon_from_url(&url)?;
                     webtoons.push(webtoon);
+                } else if let Section::SuperLike { .. } = section {
+                    // Ignore super likes
+                    continue;
                 } else {
                     bail!("Only the Webtoon meta flare can have more than one in the section group, yet encountered a case where there was more than one of another flare type: {section:?}");
                 }
@@ -767,6 +771,8 @@ impl TryFrom<(&Episode, webtoons::client::posts::Post)> for Post {
                         let webtoon = episode.webtoon.client.webtoon_from_url(&url)?;
                         Some(Flare::Webtoons(vec![webtoon]))
                     }
+                    // Ignore super likes
+                    Section::SuperLike { .. } => None,
                 },
                 None => None,
             }


### PR DESCRIPTION
So far this is just supporting the parsing. There is nothing done on the other end; `Flare` has no `SuperLike` variant.