### PR TITLE
doc(posts): if no session default to `Reaction::None`

### DIFF
--- a/src/platform/webtoons/webtoon/episode/posts.rs
+++ b/src/platform/webtoons/webtoon/episode/posts.rs
@@ -726,6 +726,7 @@ impl TryFrom<(&Episode, webtoons::client::posts::Post)> for Post {
         } else if did_dislike {
             Reaction::Downvote
         } else {
+            // Defaults to `None` if no session was available for use.
             Reaction::None
         };
 


### PR DESCRIPTION
When a session is used reaction data is returned in the api. If no session is used it defaults to an empty list. Following this convention, if there is no session then it will also default to no reaction, represented by `Reaction::None`.