### PR TITLE
fix(client): return proper deserialization error for `userInfo` endpoint

### DIFF
--- a/src/platform/webtoons/client.rs
+++ b/src/platform/webtoons/client.rs
@@ -848,7 +848,9 @@ impl Client {
             .await?
             .json()
             .await
-            .context("`userInfo` json should have a `loginUser`field")?;
+            .map_err(|err| {
+                ClientError::Unexpected(anyhow!("failed to deserialize `userInfo` endpoint: {err}"))
+            })?;
         Ok(user_info)
     }
 


### PR DESCRIPTION
When deserialization of the `userInfo` failed it would always say it should have a `loginUser` field even when other fields could trigger this. Now it returns the actual error on deserialization.