### PR TITLE
fix: webtoon thumbnail parse

### DIFF
--- a/src/platform/webtoons/webtoon/page/en.rs
+++ b/src/platform/webtoons/webtoon/page/en.rs
@@ -360,7 +360,10 @@ pub fn original_thumbnail(html: &Html) -> Result<Url, WebtoonError> {
         .captures(style)
         .context("failed to find thumbail url on page: should have `url(...)` in style tag")?;
 
-    let mut thumbnail = Url::parse(&cap["url"])?;
+    // Url is surrounded by single quotes: `'`
+    let url = cap["url"].trim_matches('\'');
+
+    let mut thumbnail = Url::parse(url)?;
 
     thumbnail
         // This host doesn't need a `referer` header to see the image.

--- a/src/platform/webtoons/webtoon/rss.rs
+++ b/src/platform/webtoons/webtoon/rss.rs
@@ -106,7 +106,7 @@ pub(super) async fn feed(webtoon: &Webtoon) -> Result<Rss, WebtoonError> {
             page: Arc::new(Mutex::new(None)),
             views: None,
             ad_status: None,
-            // RSS can only be generated for public and free(not behiong ad or fast-pass) episodes.
+            // RSS can only be generated for public and free(not behind ad or fast-pass) episodes.
             published_status: Some(PublishedStatus::Published),
         });
     }


### PR DESCRIPTION
The contents inside `url(...)` are now surrounded by `'`. This PR trims them away.