### PR TITLE
fix(client): add retry when encounter a 429 response

### DIFF
--- a/src/platform/webtoons/canvas.rs
+++ b/src/platform/webtoons/canvas.rs
@@ -59,8 +59,8 @@ pub(super) async fn scrape(
     for page in start..end {
         let response = match client.get_canvas_page(language, page, sort).await {
             Ok(response) => response,
-            Err(ClientError::RateLimitExceeded(retry_after)) => {
-                tokio::time::sleep(Duration::from_secs(retry_after)).await;
+            Err(ClientError::RateLimitExceeded) => {
+                tokio::time::sleep(Duration::from_secs(10)).await;
                 client.get_canvas_page(language, page, sort).await?
             }
             Err(err) => return Err(CanvasError::ClientError(err)),

--- a/src/platform/webtoons/errors.rs
+++ b/src/platform/webtoons/errors.rs
@@ -40,7 +40,7 @@ pub enum ClientError {
     #[error("Provided session is invalid or expired")]
     InvalidSession,
     #[error("Rate limit was exceeded")]
-    RateLimitExceeded(u64),
+    RateLimitExceeded,
     #[error(transparent)]
     Unexpected(#[from] anyhow::Error),
 }

--- a/src/platform/webtoons/webtoon/episode.rs
+++ b/src/platform/webtoons/webtoon/episode.rs
@@ -1232,18 +1232,7 @@ impl Episode {
         }
 
         if response.status() == 429 {
-            let retry_after: u64 = response
-                .headers()
-                .get("Retry-After")
-                .expect("A 429 HTTP response should always have a `Retry-After` header")
-                .to_str()
-                .expect("`Retry-After` value should always be ascii digits")
-                .parse()
-                .expect("`Retry-After` should always be parsable digits");
-
-            return Err(EpisodeError::ClientError(ClientError::RateLimitExceeded(
-                retry_after,
-            )));
+            return Err(EpisodeError::ClientError(ClientError::RateLimitExceeded));
         }
 
         let text = response.text().await?;


### PR DESCRIPTION
Due to the 429 response body not being json, the deserialization was falling with `failed to decode response body`. Now, the response body is checked for the response text and proceeds to retry if needed.