### PR TITLE
refactor(tests): use `has_session` instead of `has_valid_session`

### DIFF
--- a/examples/webtoon.rs
+++ b/examples/webtoon.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Error> {
     println!("rating: {}", webtoon.rating().await?);
     println!("summary: {}", webtoon.summary().await?);
 
-    if let Ok(true) = client.has_valid_session().await {
+    if client.has_session() {
         webtoon.rate(10).await?;
         webtoon.is_subscribed().await?;
         webtoon.subscribe().await?;

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -75,7 +75,7 @@ async fn webtoon() -> Result<(), Error> {
     let _rating = webtoon.rating().await.unwrap();
     let _summary = webtoon.summary().await.unwrap();
 
-    if let Ok(true) = client.has_valid_session().await {
+    if client.has_session() {
         webtoon.rate(10).await.unwrap();
         webtoon.is_subscribed().await.unwrap();
         webtoon.subscribe().await.unwrap();
@@ -100,12 +100,7 @@ async fn posts() -> Result<(), Error> {
         .unwrap()
         .expect("No episode for given number");
 
-    let has_session = client
-        .has_valid_session()
-        .await
-        .is_ok_and(|has_session| has_session);
-
-    if has_session {
+    if client.has_session() {
         // Post content and if its marked as a spoiler.
         episode.post("MESSAGE", false).await.unwrap();
     }
@@ -115,7 +110,7 @@ async fn posts() -> Result<(), Error> {
     for post in posts {
         for _reply in post.replies::<Posts>().await.unwrap() {}
 
-        if has_session {
+        if client.has_session() {
             post.upvote().await.unwrap();
             post.downvote().await.unwrap();
             post.unvote().await.unwrap();


### PR DESCRIPTION
This was causing rate limits to be encountered with the `userInfo` endpoint with the rest of the test setup.