### PR TITLE
feat(genre): add supprot for new `graphic-novel`

### DIFF
--- a/src/platform/webtoons/meta.rs
+++ b/src/platform/webtoons/meta.rs
@@ -227,6 +227,7 @@ pub enum Genre {
     Adaptation,
     Shonen,
     WebNovel,
+    GraphicNovel,
 }
 
 impl Genre {
@@ -274,6 +275,7 @@ impl Genre {
             Self::Adaptation => "adaptation",
             Self::Shonen => "shonen",
             Self::WebNovel => "web-novel",
+            Self::GraphicNovel => "graphic-novel",
         }
     }
 }
@@ -380,6 +382,7 @@ impl FromStr for Genre {
             "adaptation" | "影視化" => Ok(Self::Adaptation),
             "shonen" | "少年" => Ok(Self::Shonen),
             "web-novel" | "WEBNOVEL" | "小說" | "นิยาย" => Ok(Self::WebNovel),
+            "graphic-novel" | "GRAPHIC_NOVEL" => Ok(Self::GraphicNovel),
             _ => Err(ParseGenreError(s.to_owned())),
         }
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/483166f9-92f8-4b68-89dd-72328a187fe9)

This only adds it for the english site, but this is currently the only version actively maintained by us.