### PR TITLE
fix(webtoons): properly support readers for audio episodes

### DIFF
--- a/src/platform/webtoons/webtoon/episode.rs
+++ b/src/platform/webtoons/webtoon/episode.rs
@@ -303,7 +303,7 @@ impl Episode {
     /// ```
     pub async fn length(&self) -> Result<Option<u32>, EpisodeError> {
         if let Some(page) = &*self.page.read() {
-            Ok(Some(page.length))
+            Ok(page.length)
         } else {
             let page = match self.scrape().await {
                 Ok(page) => page,
@@ -314,7 +314,7 @@ impl Episode {
             let length = page.length;
             *self.page.write() = Some(page);
 
-            Ok(Some(length))
+            Ok(length)
         }
     }
 

--- a/src/platform/webtoons/webtoon/episode/page/panels.rs
+++ b/src/platform/webtoons/webtoon/episode/page/panels.rs
@@ -71,6 +71,22 @@ impl Panel {
 
 #[allow(unused, reason = "not all features use `episode`")]
 pub(super) fn from_html(html: &Html, episode: u16) -> Result<Vec<Panel>, EpisodeError> {
+    let panels = if super::is_audio_reader(html) {
+        return Ok(Vec::new());
+    } else {
+        from_normal_reader(html, episode)?
+    };
+
+    if panels.is_empty() {
+        return Err(EpisodeError::Unexpected(anyhow!(
+            "Failed to find a single panel on episode page"
+        )));
+    }
+
+    Ok(panels)
+}
+
+fn from_normal_reader(html: &Html, episode: u16) -> Result<Vec<Panel>, EpisodeError> {
     let selector = Selector::parse(r"img._images") //
         .expect("`img._images` should be a valid selector");
 
@@ -126,12 +142,6 @@ pub(super) fn from_html(html: &Html, episode: u16) -> Result<Vec<Panel>, Episode
             ext,
             bytes: Vec::new(),
         });
-    }
-
-    if panels.is_empty() {
-        return Err(EpisodeError::Unexpected(anyhow!(
-            "Failed to find a single panel on episode page"
-        )));
     }
 
     Ok(panels)

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -147,9 +147,8 @@ async fn episode_with_normal_reader() -> Result<(), Error> {
         .unwrap()
         .expect("No episode for given number");
 
-    let title = episode.title().await?;
-
-    assert_eq!("Episode 19", title);
+    assert_eq!("Episode 19", episode.title().await?);
+    assert_eq!(Some(111800), episode.length().await?);
 
     Ok(())
 }
@@ -166,9 +165,8 @@ async fn episode_with_alternate_reader() -> Result<(), Error> {
         .unwrap()
         .expect("No episode for given number");
 
-    let title = episode.title().await?;
-
-    assert_eq!("Ep. 1 - The Busan Karaoke Ghost", title);
+    assert_eq!("Ep. 1 - The Busan Karaoke Ghost", episode.title().await?);
+    assert_eq!(None, episode.length().await?);
 
     Ok(())
 }


### PR DESCRIPTION
Some Wevtoons(536, 772, 4784) have episodes that have some kind of alternate reader, one that can play sound and show gifs. This reader does the panel forming on client side and needs js to form the html. This means we cannot get any panel related info.