### PR TITLE
perf(webtoons): parallelize `Creator::webtoons`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ all-features = true
 [dependencies]
 # currently using `Mutex`, `sleep`, and `Semaphore`.
 tokio = { version = "1", features = ["sync", "time", "fs"] }
+futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["brotli", "json", "rustls-tls"]}
 anyhow = "1"
 thiserror = "2"


### PR DESCRIPTION
For the current `creator` example, which has 5 webtoons, this speeds up the runtime from 6s to 3s. 