### PR TITLE
build(deps): remove `serde_with` from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ scraper = "0.24"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# TODO: refactor to use `try_from = "String"` so that we can remove this
-serde_with = "3"
 chrono = { version = "0.4",default-features = false, features = ["clock", "oldtime", "std", "serde"] }
 html-escape = "0.2"
 url = "2"

--- a/src/stdx/base36.rs
+++ b/src/stdx/base36.rs
@@ -1,9 +1,10 @@
-use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::{fmt::Display, num::ParseIntError, ops::Add, str::FromStr};
 
-#[derive(
-    Debug, PartialEq, Eq, PartialOrd, Ord, DeserializeFromStr, SerializeDisplay, Clone, Copy, Hash,
-)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy, Hash)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
 pub struct Base36(u32);
 
 impl Base36 {
@@ -65,6 +66,20 @@ impl Display for Base36 {
         }
 
         Ok(())
+    }
+}
+
+impl TryFrom<String> for Base36 {
+    type Error = ParseIntError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
+    }
+}
+
+impl From<Base36> for String {
+    fn from(val: Base36) -> Self {
+        val.to_string()
     }
 }
 


### PR DESCRIPTION
The functionality used was for converting via `from_str` and `Display`, both of which can be done with the build in `try_from` and `into` attribute macros.