### PR TITLE
build(features)!: add `download` and `naver` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,27 +21,38 @@ all-features = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# currently using `Mutex`, `sleep`, and `Semaphore`.
-tokio = { version = "1", features = ["sync", "time", "fs"] }
+# Currently using `Mutex`, `sleep`, and `Semaphore`.
+# When `feature = "download"` in enabled, it also uses `fs`.
+tokio = { version = "1", features = ["sync", "time"] }
 futures = "0.3"
+
+url = "2"
+# Used when the session needs to be sent in a URL
+urlencoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["brotli", "json", "rustls-tls"]}
-anyhow = "1"
-thiserror = "2"
-scraper = "0.24"
-# used for getting the url from the css of the thumbnail and the season numbers from the title
+
+# Used for getting the URL from the CSS of the thumbnail and the season numbers from the title
 regex = "1"
+
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-chrono = { version = "0.4",default-features = false, features = ["clock", "oldtime", "std", "serde"] }
-html-escape = "0.2"
-url = "2"
-# used when the session needs to be sent in a url
-urlencoding = "2"
-parking_lot = "0.12"
-fastrand = "2"
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"]}
 
-# feature = `rss`
+chrono = { version = "0.4",default-features = false, features = ["clock", "oldtime", "std", "serde"] }
+
+scraper = "0.24"
+html-escape = "0.2"
+
+parking_lot = "0.12"
+
+fastrand = "2"
+
+anyhow = "1"
+thiserror = "2"
+
+# feature = `download`
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"], optional = true}
+
+# `feature = "rss"` and `feature = "naver"`
 rss = { version = "2", optional = true }
 
 [dev-dependencies]
@@ -51,6 +62,11 @@ tokio = { version = "1", features = ["full"] }
 [features]
 default = []
 rss = ["dep:rss"]
+download = ["dep:image", "tokio/fs"]
+# `image` is needed as currently the only way to get the size of the episodes is
+# to download the panels and then convert them to an image and use the metadata
+# to get the sizes.
+naver = ["dep:image"]
 
 # `webtoons.com`
 [[example]]
@@ -89,28 +105,35 @@ path = "examples/webtoons/posts.rs"
 [[example]]
 name = "webtoons-download"
 path = "examples/webtoons/download.rs"
+required-features = ["download"]
 
 # `comic.naver.com`
 [[example]]
 name = "naver-webtoon"
 path = "examples/naver/webtoon.rs"
+required-features = ["naver"]
 
 [[example]]
 name = "naver-episodes"
 path = "examples/naver/episodes.rs"
+required-features = ["naver"]
 
 [[example]]
 name = "naver-episode"
 path = "examples/naver/episode.rs"
+required-features = ["naver"]
 
 [[example]]
 name = "naver-posts"
 path = "examples/naver/posts.rs"
+required-features = ["naver"]
 
 [[example]]
 name = "naver-download"
 path = "examples/naver/download.rs"
+required-features = ["naver", "download"]
 
 [[example]]
 name = "naver-creator"
 path = "examples/naver/creator.rs"
+required-features = ["naver"]

--- a/README.md
+++ b/README.md
@@ -99,5 +99,8 @@ async fn main() -> Result<(), Error> {
 For more examples, check out the [`examples`](https://github.com/Webtoon-Studio/webtoon/tree/main/examples) folder.
 
 ## Features
+In an effort to reduce compile times, dependency trees, and binary sizes, there are some pieces of functionality that are locked behind features.
 
 - `rss`: Enables the ability to get the RSS feed data for a `webtoons.com`.
+- `naver`: Enables the ability to interact with `comic.naver.com`.
+- `download`: Enables the ability to download episodes, either as a single image or as multiple images.

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,4 +1,5 @@
 //! Module representing the platforms that this crate supports.
 
+#[cfg(feature = "naver")]
 pub mod naver;
 pub mod webtoons;

--- a/src/platform/naver/errors.rs
+++ b/src/platform/naver/errors.rs
@@ -16,6 +16,8 @@ pub enum Error {
     EpisodeError(#[from] EpisodeError),
     #[error(transparent)]
     PostError(#[from] PostError),
+
+    #[cfg(feature = "download")]
     #[error(transparent)]
     DownloadError(#[from] DownloadError),
 }
@@ -110,6 +112,7 @@ impl From<reqwest::Error> for PostError {
     }
 }
 
+#[cfg(feature = "download")]
 #[allow(missing_docs)]
 #[non_exhaustive]
 #[derive(Debug, Error)]
@@ -122,6 +125,7 @@ pub enum DownloadError {
     Unexpected(#[from] anyhow::Error),
 }
 
+#[cfg(feature = "download")]
 impl From<reqwest::Error> for DownloadError {
     fn from(error: reqwest::Error) -> Self {
         Self::ClientError(ClientError::from(error))

--- a/src/platform/naver/webtoon/episode/page/panels.rs
+++ b/src/platform/naver/webtoon/episode/page/panels.rs
@@ -1,14 +1,12 @@
-use crate::platform::naver::{Client, errors::DownloadError, webtoon::episode::EpisodeError};
+use crate::platform::naver::{Client, webtoon::episode::EpisodeError};
 use anyhow::Context;
-use image::{GenericImageView, ImageFormat, RgbaImage};
 use scraper::{Html, Selector};
-use std::path::Path;
-use tokio::{fs::File, io::AsyncWriteExt};
 use url::Url;
 
 /// Represents a single panel for an episode.
 ///
 /// This type is not constructed directly, but gotten via [`Episode::panels()`](crate::platform::naver::webtoon::episode::Episode::panels()).
+#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct Panel {
     pub(crate) url: Url,
@@ -98,6 +96,7 @@ pub(super) fn from_html(html: &Html, episode: u16) -> Result<Vec<Panel>, Episode
 /// Represents all the downloaded panels for an episode.
 ///
 /// This type is not constructed directly, but gotten via [`Episode::download()`](crate::platform::naver::webtoon::episode::Episode::download()).
+#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct Panels {
     pub(crate) images: Vec<Panel>,
@@ -105,6 +104,14 @@ pub struct Panels {
     pub(crate) width: u32,
 }
 
+#[cfg(feature = "download")]
+use crate::platform::naver::errors::DownloadError;
+#[cfg(feature = "download")]
+use image::{GenericImageView, ImageFormat, RgbaImage};
+#[cfg(feature = "download")]
+use tokio::{fs::File, io::AsyncWriteExt};
+
+#[cfg(feature = "download")]
 impl Panels {
     /// Saves all the panels of an episode as a single, long image file in `png` format.
     ///
@@ -135,7 +142,7 @@ impl Panels {
     /// ```
     pub async fn save_single<P>(&self, path: P) -> Result<(), DownloadError>
     where
-        P: AsRef<Path> + Send,
+        P: AsRef<std::path::Path> + Send,
     {
         let path = path.as_ref();
 
@@ -201,7 +208,7 @@ impl Panels {
     /// ```
     pub async fn save_multiple<P>(&self, path: P) -> Result<(), DownloadError>
     where
-        P: AsRef<Path> + Send,
+        P: AsRef<std::path::Path> + Send,
     {
         let path = path.as_ref();
 

--- a/src/platform/webtoons/errors.rs
+++ b/src/platform/webtoons/errors.rs
@@ -26,6 +26,8 @@ pub enum Error {
     ReplyError(#[from] ReplyError),
     #[error(transparent)]
     PosterError(#[from] PosterError),
+
+    #[cfg(feature = "download")]
     #[error(transparent)]
     DownloadError(#[from] DownloadError),
 }
@@ -220,6 +222,7 @@ impl From<reqwest::Error> for SearchError {
     }
 }
 
+#[cfg(feature = "download")]
 #[allow(missing_docs)]
 #[non_exhaustive]
 #[derive(Debug, Error)]
@@ -232,6 +235,7 @@ pub enum DownloadError {
     Unexpected(#[from] anyhow::Error),
 }
 
+#[cfg(feature = "download")]
 impl From<reqwest::Error> for DownloadError {
     fn from(error: reqwest::Error) -> Self {
         Self::ClientError(ClientError::from(error))


### PR DESCRIPTION
This makes `image` an optional dependency, as well as make `tokio/fs` locked behind `download`, as this is actually when it would be used. As part of some naver weirdness, the `naver` feature enables `image`, and the sole reason why there is a `naver` feature in the first place, is because to get the episodes lengths, the panels must be downloaded first, then read from memory as an `image`, and then using the metadata, get the size; unlike `webtoons`, `naver` does not provide anyway to parse the sizes without downloading first.

BREAKING: This will require users to add flags for previously default things.