### PR TITLE
build: remove `.cargo/config.toml`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Clink-arg=-fuse-ld=mold
 
 jobs:
   test:

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Clink-arg=-fuse-ld=mold
 
 jobs:
   test:


### PR DESCRIPTION
This config has the highest priority and will override devs global config, which may have other linkers, like `wild`, which they would prefer instead.