### PR TITLE
chore: bump MSRV to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webtoon"
 version = "0.9.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Webtoon-Studio/webtoon/"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Supported:
 
 ### Installation
 
-MSRV: `1.85.0`
+MSRV: `1.88.0`
 
 To use this library, add `webtoon` to your `Cargo.toml`:
 


### PR DESCRIPTION
We will now be using `let-chains`, which stabilized in [`1.88.0`](https://releases.rs/docs/1.88.0/).