### PR TITLE
fix(webtoons/episode): support gif image format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "2"
 error_set = "0.9.0"
 
 # feature = `download`
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"], optional = true}
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif"], optional = true}
 # `feature = "rss"`
 rss = { version = "2", optional = true, default-features = false }
 

--- a/src/platform/webtoons/webtoon/episode.rs
+++ b/src/platform/webtoons/webtoon/episode.rs
@@ -1799,15 +1799,13 @@ fn panels(html: &Html, episode: u16) -> Result<Vec<Panel>, Assumption> {
             ),
         };
 
-        // TODO: `gif` is a supported format in some instances, despite wording that states
-        // only JPEG and PNG are accepted. Need to figure out how to save the image when
-        // saving as a single image. Multiple images should be fine as can just save each
-        // separately with their own ext.
+        // NOTE: `gif` is a supported format in some instances, despite wording that states
+        // only JPEG and PNG are accepted.
         assumption!(
-            ["jpeg", "JPEG", "png", "PNG", "jpg", "JPG"]
+            ["jpeg", "JPEG", "png", "PNG", "jpg", "JPG", "gif", "GIF"]
                 .into_iter()
                 .any(|format| format == ext),
-            "`webtoons.com` limits the image formats to just JPEG(`jpeg`, `jpg`) and PNG(`png`), but found: `{ext}`"
+            "`webtoons.com` limits the image formats to just JPEG(`jpeg`, `jpg`), PNG(`png`), and GIF(`gif`, `GIF`), but found: `{ext}`"
         );
 
         panels.push(Panel {
@@ -1905,7 +1903,6 @@ use image::{GenericImageView, ImageFormat, RgbaImage};
 #[cfg(feature = "download")]
 use tokio::io::AsyncWriteExt;
 
-// TODO: Make `no_run` and add integration tests instead that covers canvas and original.
 // TODO: technically this should not have `DownloadError` as panels are already
 // downloaded, and this can only really fail saving to disk.
 #[cfg(feature = "download")]
@@ -1920,7 +1917,7 @@ impl Panels {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # use webtoon::platform::webtoons::{error::Error, Client, Type};
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Error> {
@@ -2007,7 +2004,7 @@ impl Panels {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # use webtoon::platform::webtoons::{error::Error, Client, Type};
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Error> {

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -643,7 +643,10 @@ async fn english_canvas_download_single() {
     assert_eq!(15, panels.count());
 
     // Save as a single, long image.
-    panels.save_single("tests/panels").await.unwrap();
+    panels
+        .save_single("target/tmp/english_canvas_single/")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -663,7 +666,10 @@ async fn english_original_download_single() {
     assert_eq!(43, panels.count());
 
     // Save as a single, long image.
-    panels.save_single("tests/panels").await.unwrap();
+    panels
+        .save_single("target/tmp/english_original_single/")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -683,7 +689,10 @@ async fn english_canvas_download_multi() {
     assert_eq!(1, panels.count());
 
     // Save each individual panel as a separate image.
-    panels.save_multiple("tests/panels").await.unwrap();
+    panels
+        .save_multiple("target/tmp/english_canvas_multi/")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -703,7 +712,10 @@ async fn english_original_download_multi() {
     assert_eq!(160, panels.count());
 
     // Save each individual panel as a separate image.
-    panels.save_multiple("tests/panels").await.unwrap();
+    panels
+        .save_multiple("target/tmp/english_original_multi/")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -860,12 +872,15 @@ async fn english_originals_korean_creator_with_spaces_should_be_ok() {
 }
 
 #[tokio::test]
-#[ignore = "need to figure out how to handle saving gifs to disk when saving as a single image"]
 async fn english_originals_with_gif() {
     let client = Client::new();
     let webtoon = client.webtoon(2757, Type::Original).await.unwrap().unwrap();
 
     let episode = webtoon.episode(25).await.unwrap().unwrap();
 
-    let _length = episode.length().await.unwrap();
+    let panels = episode.download().await.unwrap();
+    panels
+        .save_single("target/tmp/gif_in_single_png/")
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
When saving a gif as a png, it saves the first animation frame as the image. This approach is taken as gifs are not actually supposed to be allowed, with `webtoons.com` stating that only png and jpeg formats are allowed. Until a problem arises we just accept that the first animation frame is good enough. 

Potentially, if needed, we can instead returns an error on the single image save that there is a gif. The multi image save is fine as it used the ext the panels came with, which in this case, should save a gif just fine, animation frames and all. 