### PR TITLE
refactor(webtoons/episode)!: introduce a `Published` abstraction over date and datetime

### DIFF
--- a/examples/webtoons/originals.rs
+++ b/examples/webtoons/originals.rs
@@ -15,7 +15,11 @@ async fn main() -> anyhow::Result<()> {
         let first_episode = webtoon.first_episode().await?;
 
         // Check for all Webtoons who's first episode was published within the last 30 days.
-        if first_episode.published() >= Some(thirty_days_ago.timestamp_millis()) {
+        if first_episode
+            .published()
+            .and_then(|published| published.timestamp())
+            >= Some(thirty_days_ago.timestamp_millis())
+        {
             println!("New Webtoon! `{}`", webtoon.title().await?);
         }
     }

--- a/src/platform/webtoons/dashboard/episodes.rs
+++ b/src/platform/webtoons/dashboard/episodes.rs
@@ -7,7 +7,7 @@ use crate::{
         error::SessionError,
         webtoon::{
             Webtoon,
-            episode::{self, AdStatus, Episode},
+            episode::{self, AdStatus, Episode, Published},
         },
     },
     stdx::{cache::Cache, error::assumption, math::MathExt},
@@ -47,7 +47,7 @@ pub async fn scrape(webtoon: &Webtoon) -> Result<Vec<Episode>, SessionError> {
 
     for episode in dashboard_episodes {
         let published = match episode.published.map(DateTime::from_timestamp_millis) {
-            Some(Some(published)) => Some(published),
+            Some(Some(published)) => Some(Published::from(published)),
             Some(None) => assumption!(
                 "`webtoons.com` should always return a valid unix millisecond timestamp, got: {:?}",
                 episode.published
@@ -77,7 +77,7 @@ pub async fn scrape(webtoon: &Webtoon) -> Result<Vec<Episode>, SessionError> {
 
         for episode in dashboard_episodes {
             let published = match episode.published.map(DateTime::from_timestamp_millis) {
-                Some(Some(published)) => Some(published),
+                Some(Some(published)) => Some(Published::from(published)),
                 Some(None) => assumption!(
                     "`webtoons.com` should always return a valid unix millisecond timestamp, got: {:?}",
                     episode.published

--- a/src/platform/webtoons/webtoon/post.rs
+++ b/src/platform/webtoons/webtoon/post.rs
@@ -1797,11 +1797,11 @@ pub mod id {
         }
     }
 
+    #[allow(
+        clippy::non_canonical_partial_ord_impl,
+        reason = "`Id` ordering is only meaningful for the same webtoon on the same episode"
+    )]
     impl PartialOrd for Id {
-        #[allow(
-            clippy::non_canonical_partial_ord_impl,
-            reason = "`Id` ordering is only meaningful for the same webtoon on the same episode"
-        )]
         fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
             // If not a post on the same webtoons' episode then return `None`.
             // Cannot add `self.tag != other.tag` as its still unknown how this number increments, but given that the other

--- a/src/platform/webtoons/webtoon/rss.rs
+++ b/src/platform/webtoons/webtoon/rss.rs
@@ -5,7 +5,9 @@ use std::str::FromStr;
 use url::Url;
 
 use crate::{
-    platform::webtoons::{Language, creator::Creator, error::RssError},
+    platform::webtoons::{
+        Language, creator::Creator, error::RssError, webtoon::episode::Published,
+    },
     stdx::{
         cache::Cache,
         error::{Assume, Assumption, assumption},
@@ -74,7 +76,7 @@ pub(super) async fn feed(webtoon: &Webtoon) -> Result<Rss, RssError> {
     let mut episodes = Vec::new();
 
     for item in &channel.items {
-        let published = published(
+        let datetime = published(
             item.pub_date()
                 .assumption("publish date should always be present in `webtoons.com` rss feed, as this feed only shows published episodes")?,
             webtoon.language(),
@@ -96,7 +98,7 @@ pub(super) async fn feed(webtoon: &Webtoon) -> Result<Rss, RssError> {
             webtoon: webtoon.clone(),
             number,
             title: Cache::new(title),
-            published: Some(published),
+            published: Some(Published::from(datetime)),
             // RSS can only be generated for public and free(not behind ad or fast-pass) episodes.
             published_status: Some(PublishedStatus::Published),
 

--- a/src/stdx.rs
+++ b/src/stdx.rs
@@ -4,3 +4,4 @@ pub mod error;
 pub mod http;
 pub mod math;
 pub mod serde;
+pub mod time;

--- a/src/stdx/time.rs
+++ b/src/stdx/time.rs
@@ -1,0 +1,79 @@
+use chrono::{DateTime, Datelike, NaiveDate, Timelike, Utc};
+
+#[derive(Debug, Clone, Copy)]
+pub enum DateOrDateTime {
+    Date(NaiveDate),
+    DateTime(DateTime<Utc>),
+}
+
+impl DateOrDateTime {
+    #[inline]
+    pub fn day(&self) -> u32 {
+        match self {
+            Self::Date(naive_date) => naive_date.day(),
+            Self::DateTime(date_time) => date_time.day(),
+        }
+    }
+
+    #[inline]
+    pub fn month(&self) -> u32 {
+        match self {
+            Self::Date(naive_date) => naive_date.month(),
+            Self::DateTime(date_time) => date_time.month(),
+        }
+    }
+
+    #[inline]
+    pub fn year(&self) -> i32 {
+        match self {
+            Self::Date(naive_date) => naive_date.year(),
+            Self::DateTime(date_time) => date_time.year(),
+        }
+    }
+
+    #[inline]
+    pub fn hour(&self) -> Option<u32> {
+        match self {
+            Self::Date(_) => None,
+            Self::DateTime(date_time) => Some(date_time.hour()),
+        }
+    }
+
+    #[inline]
+    pub fn minute(&self) -> Option<u32> {
+        match self {
+            Self::Date(_) => None,
+            Self::DateTime(date_time) => Some(date_time.minute()),
+        }
+    }
+
+    #[inline]
+    pub fn second(&self) -> Option<u32> {
+        match self {
+            Self::Date(_) => None,
+            Self::DateTime(date_time) => Some(date_time.second()),
+        }
+    }
+
+    #[inline]
+    pub fn timestamp(&self) -> Option<i64> {
+        match self {
+            Self::Date(_) => None,
+            Self::DateTime(date_time) => Some(date_time.timestamp()),
+        }
+    }
+}
+
+impl From<NaiveDate> for DateOrDateTime {
+    #[inline]
+    fn from(date: NaiveDate) -> Self {
+        Self::Date(date)
+    }
+}
+
+impl From<DateTime<Utc>> for DateOrDateTime {
+    #[inline]
+    fn from(datetime: DateTime<Utc>) -> Self {
+        Self::DateTime(datetime)
+    }
+}


### PR DESCRIPTION
This introduces a `Published` struct which wraps a `DateOrDateTime`. For an `Episode`, its not always possible to get the full time precision of when it was published. Before, we were just defaulting to 2:00am UTC, but this is just incorrect. Instead, we now abstract when there is no time information, while still exposing ways to get the full precision via methods on `Published`, should they be available.