### PR TITLE
refactor(webtoons/episode): remove `season` from `Episode`

### DIFF
--- a/src/platform/webtoons/dashboard/episodes.rs
+++ b/src/platform/webtoons/dashboard/episodes.rs
@@ -7,7 +7,7 @@ use crate::{
         error::SessionError,
         webtoon::{
             Webtoon,
-            episode::{self, AdStatus, Episode, Published},
+            episode::{AdStatus, Episode, Published},
         },
     },
     stdx::{cache::Cache, error::assumption, math::MathExt},
@@ -58,7 +58,6 @@ pub async fn scrape(webtoon: &Webtoon) -> Result<Vec<Episode>, SessionError> {
         episodes.insert(Episode {
             webtoon: webtoon.clone(),
             number: episode.metadata.number,
-            season: Cache::new(episode::season(&episode.metadata.title)?),
             title: Cache::new(episode.metadata.title),
             published,
             views: Some(episode.metadata.views),
@@ -88,7 +87,6 @@ pub async fn scrape(webtoon: &Webtoon) -> Result<Vec<Episode>, SessionError> {
             episodes.insert(Episode {
                 webtoon: webtoon.clone(),
                 number: episode.metadata.number,
-                season: Cache::new(episode::season(&episode.metadata.title)?),
                 title: Cache::new(episode.metadata.title),
                 published,
                 views: Some(episode.metadata.views),

--- a/src/platform/webtoons/webtoon/episode.rs
+++ b/src/platform/webtoons/webtoon/episode.rs
@@ -168,8 +168,6 @@ impl IntoIterator for Episodes {
 pub struct Episode {
     pub(crate) webtoon: Webtoon,
     pub(crate) number: u16,
-    // TODO: Need to store? Should be pretty cheap to compute on the fly as title is most likely cached.
-    pub(crate) season: Cache<Option<u8>>,
     pub(crate) title: Cache<String>,
     pub(crate) published: Option<Published>,
     pub(crate) length: Cache<Option<u32>>,
@@ -186,7 +184,6 @@ impl std::fmt::Debug for Episode {
         let Self {
             webtoon: _,
             number,
-            season,
             title,
             published,
             length,
@@ -200,7 +197,6 @@ impl std::fmt::Debug for Episode {
 
         f.debug_struct("Episode")
             .field("number", number)
-            .field("season", season)
             .field("title", title)
             .field("published", published)
             .field("length", length)
@@ -325,11 +321,7 @@ impl Episode {
     /// ```
     pub async fn season(&self) -> Result<Option<u8>, EpisodeError> {
         let title = self.title().await?;
-
-        let season = self::season(&title)?;
-        self.season.insert(season);
-
-        Ok(season)
+        Ok(self::season(&title)?)
     }
 
     /// Returns the creator note for episode.
@@ -1326,7 +1318,6 @@ impl Episode {
             webtoon: webtoon.clone(),
             number,
 
-            season: Cache::empty(),
             title: Cache::empty(),
             // NOTE:
             // Currently there is no way to get this info from an episodes page.

--- a/src/platform/webtoons/webtoon/homepage/en.rs
+++ b/src/platform/webtoons/webtoon/homepage/en.rs
@@ -1,7 +1,4 @@
-use super::{
-    super::episode::{self, PublishedStatus},
-    Page,
-};
+use super::{super::episode::PublishedStatus, Page};
 use crate::{
     platform::webtoons::{
         Client, Language, Type, Webtoon,
@@ -638,7 +635,6 @@ pub(super) fn episode(element: &ElementRef<'_>, webtoon: &Webtoon) -> Result<Epi
 
     Ok(Episode {
         webtoon: webtoon.clone(),
-        season: Cache::new(episode::season(&title)?),
         title: Cache::new(title),
         number,
         published: Some(Published::from(date)),

--- a/src/platform/webtoons/webtoon/rss.rs
+++ b/src/platform/webtoons/webtoon/rss.rs
@@ -102,7 +102,6 @@ pub(super) async fn feed(webtoon: &Webtoon) -> Result<Rss, RssError> {
             // RSS can only be generated for public and free(not behind ad or fast-pass) episodes.
             published_status: Some(PublishedStatus::Published),
 
-            season: Cache::empty(),
             length: Cache::empty(),
             thumbnail: Cache::empty(),
             note: Cache::empty(),


### PR DESCRIPTION
There really isn't a need to keep this kind of caching and state around when it can easily be gotten from the already cached title. 