### PR TITLE
refactor(webtoons): remove `Posts` and use `Vec<Post>`

### DIFF
--- a/examples/webtoons/posts.rs
+++ b/examples/webtoons/posts.rs
@@ -2,7 +2,6 @@ use tokio::io::AsyncWriteExt;
 use webtoon::platform::webtoons::{
     Client, Type,
     error::{BlockUserError, Error},
-    webtoon::post::Posts,
 };
 
 #[tokio::main(flavor = "current_thread")]
@@ -39,11 +38,11 @@ async fn main() -> Result<(), Error> {
         println!("flare: {:?}", post.body().flare());
         println!("upvotes: {}", post.upvotes());
         println!("downvotes: {}", post.downvotes());
-        let replies: u32 = post.replies().await?;
+        let replies = post.reply_count();
         println!("replies: {replies}");
         println!("super like: {:?}", post.poster().super_like());
 
-        for reply in post.replies::<Posts>().await? {
+        for reply in post.replies().await? {
             println!("\tusername: {}", reply.poster().username());
             println!("\tcontents: {}", reply.body().contents());
             println!("\tis spoiler: {}", reply.body().is_spoiler());

--- a/src/platform/webtoons/webtoon.rs
+++ b/src/platform/webtoons/webtoon.rs
@@ -15,7 +15,6 @@ use rss::Rss;
 use self::{
     episode::{Episode, Episodes},
     homepage::Page,
-    post::Posts,
 };
 use super::Type;
 use super::error::WebtoonError;
@@ -23,9 +22,12 @@ use super::meta::{Genre, Scope};
 use super::originals::Schedule;
 use super::{Client, Language, creator::Creator};
 use crate::{
-    platform::webtoons::error::{
-        EpisodesError, InvalidWebtoonUrl, LikesError, PostsError, RequestError, SessionError,
-        SubscribersError, ViewsError,
+    platform::webtoons::{
+        error::{
+            EpisodesError, InvalidWebtoonUrl, LikesError, PostsError, RequestError, SessionError,
+            SubscribersError, ViewsError,
+        },
+        webtoon::post::Post,
     },
     stdx::{
         cache::{Cache, Store},
@@ -936,7 +938,7 @@ impl Webtoon {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn posts(&self) -> Result<Posts, PostsError> {
+    pub async fn posts(&self) -> Result<Vec<Post>, PostsError> {
         let mut posts = Vec::with_capacity(100);
 
         for number in 1.. {
@@ -947,7 +949,7 @@ impl Webtoon {
             }
         }
 
-        Ok(Posts::from(posts))
+        Ok(posts)
     }
 
     /// Retrieves the RSS feed information for the current `Webtoon`.

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -3,7 +3,6 @@ use webtoon::platform::webtoons::{
     canvas::Sort,
     meta::Genre,
     originals::{Schedule, Weekday},
-    webtoon::post::Posts,
 };
 
 #[tokio::test]
@@ -524,7 +523,7 @@ async fn englsh_canvas_posts() {
             // Delete just added post
             post.delete().await.unwrap();
         } else {
-            for reply in post.replies::<Posts>().await.unwrap() {
+            for reply in post.replies().await.unwrap() {
                 _ = std::hint::black_box(reply);
             }
         }
@@ -566,7 +565,7 @@ async fn englsh_canvas_posts() {
         // This refreshes to get new data for posts
         // and therefore can find all replies with `REPLY`.
         for post in episode.posts().await.unwrap() {
-            for reply in post.replies::<Posts>().await.unwrap() {
+            for reply in post.replies().await.unwrap() {
                 if reply.body().contents() == "REPLY" {
                     reply.delete().await.unwrap();
                 }
@@ -602,7 +601,7 @@ async fn englsh_original_posts() {
     let posts = episode.posts().await.unwrap();
 
     for post in posts {
-        for _reply in post.replies::<Posts>().await.unwrap() {}
+        for _reply in post.replies().await.unwrap() {}
 
         if client
             .has_valid_session()

--- a/tests/webtoons_smoke.rs
+++ b/tests/webtoons_smoke.rs
@@ -1,6 +1,4 @@
-use webtoon::platform::webtoons::{
-    Client, Language, canvas::Sort, error::CreatorError, webtoon::post::Posts,
-};
+use webtoon::platform::webtoons::{Client, Language, canvas::Sort, error::CreatorError};
 
 #[tokio::test]
 #[ignore]
@@ -72,8 +70,7 @@ async fn canvas() {
 
         episode
             .posts_for_each(async |post| {
-                let _replies = post.replies::<u32>().await.unwrap();
-                let _replies = post.replies::<Posts>().await.unwrap();
+                let _replies = post.replies().await.unwrap();
             })
             .await
             .unwrap();
@@ -157,8 +154,7 @@ async fn originals() {
 
         episode
             .posts_for_each(async |post| {
-                let _replies = post.replies::<u32>().await.unwrap();
-                let _replies = post.replies::<Posts>().await.unwrap();
+                let _replies = post.replies().await.unwrap();
             })
             .await
             .unwrap();


### PR DESCRIPTION
`Posts` was meant as a convenience layer, but the indirection to the underlying `Vec` was malformed. Using `Vec<Post>` standard manipulation with no need to special functions to add.

This also now frees up other options, like changing to add a `Vec<Reply>` and turn `Vec<Post>` to a `Vec<Comment>`, without having to make a `Replies` struct. Things become a liter more straight forward.

Currently preserving the sorted, being by newest, order. This is what tests are built around, but unsure if want to make a stability guarantee for. For now, there is no documentation stating any order.

By nature, this PR also gets rid of the also bad formed `Replies` trait, which facilitated the smashing of rely count and the actual replies. There is now a `reply_count` that returns the number value.