### PR TITLE
fix(webtoons/homepage): handle names with trailing `...`

### DIFF
--- a/src/platform/webtoons/webtoon/homepage/en.rs
+++ b/src/platform/webtoons/webtoon/homepage/en.rs
@@ -222,11 +222,14 @@ pub(super) fn creators(
                 // with multiple creators, there are (for some reason) tabs in the text:
                 //     - `" SUMPUL , HereLee , Alphatart ... "`: https://www.webtoons.com/en/fantasy/the-remarried-empress/list?title_no=2135
                 // This should allow commas in usernames, while still filtering away the standalone `,` separator.
-                'username: for username in text.trim().split('\t').filter(|&str| str.trim() != ",")
+                'username: for username in text
+                    .trim()
+                    .split('\t')
+                    .map(|str| str.trim())
+                    .filter(|&str| str != ",")
+                    // Last username in a multi-username scenario ends with ` ... `
+                    .filter(|&str| str != "...")
                 {
-                    // Last username in a multi-username scenario with end with ` ... `
-                    let username = username.trim().trim_end_matches("...");
-
                     if username.is_empty() {
                         continue;
                     }
@@ -243,7 +246,7 @@ pub(super) fn creators(
                         client: client.clone(),
                         language: Language::En,
                         profile: None,
-                        username: username.trim().into(),
+                        username: username.to_string(),
                         homepage: Cache::empty(),
                     });
                 }

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -883,3 +883,12 @@ async fn english_originals_with_gif() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn english_canvas_creator_with_multiple_trailing_dots_is_ok() {
+    let client = Client::new();
+    let webtoon = client.webtoon(557095, Type::Canvas).await.unwrap().unwrap();
+    // `That 1 kid.....`
+    let creators = webtoon.creators().await.unwrap();
+    assert!(creators.len() == 1);
+}


### PR DESCRIPTION
Caught in the smoke test, https://www.webtoons.com/en/canvas/wielders/list?title_no=557095 has a username of `That 1 kid.....`, which had issued as the logic unconditionally trimmed the final 3 `.`, leading to a double insert with the second being `That 1 kid..`.

This PR adjusts the logic to account for this.