### PR TITLE
refactor(webtoons): wrap `Post` with `Comment` and `Reply

### DIFF
--- a/examples/webtoons/posts.rs
+++ b/examples/webtoons/posts.rs
@@ -1,48 +1,34 @@
-use tokio::io::AsyncWriteExt;
-use webtoon::platform::webtoons::{
-    Client, Type,
-    error::{BlockUserError, Error},
-};
+use webtoon::platform::webtoons::{Client, Type, error::Error};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Error> {
-    let client = match std::env::var("WEBTOON_SESSION") {
-        Ok(session) if !session.is_empty() => Client::with_session(&session),
-        _ => Client::new(),
-    };
+    let client = Client::new();
 
-    let Some(webtoon) = client.webtoon(805407, Type::Canvas).await? else {
-        panic!("No webtoon of given id and type exits");
-    };
+    let webtoon = client
+        .webtoon(805407, Type::Canvas)
+        .await?
+        .expect("webtoon is known to exist");
 
     let episode = webtoon
         .episode(2)
         .await?
-        .expect("No episode for given number");
+        .expect("episode is known to exist");
 
-    if client.has_valid_session().await.is_ok_and(|result| result) {
-        // Post content and if its marked as a spoiler.
-        episode.post("MESSAGE", false).await?;
-    }
+    let mut comments = episode.posts();
 
-    println!("Getting posts, could take a while...");
-    let posts = episode.posts().await?;
-    println!("Posts gotten!");
-
-    println!();
-
-    for post in posts {
-        println!("username: {}", post.poster().username());
-        println!("contents: {}", post.body().contents());
-        println!("is spoiler: {}", post.body().is_spoiler());
-        println!("flare: {:?}", post.body().flare());
-        println!("upvotes: {}", post.upvotes());
-        println!("downvotes: {}", post.downvotes());
-        let replies = post.reply_count();
+    while let Some(comment) = comments.next().await.unwrap() {
+        println!("username: {}", comment.poster().username());
+        println!("contents: {}", comment.body().contents());
+        println!("is spoiler: {}", comment.body().is_spoiler());
+        println!("flare: {:?}", comment.body().flare());
+        println!("upvotes: {}", comment.upvotes());
+        println!("downvotes: {}", comment.downvotes());
+        let replies = comment.reply_count();
         println!("replies: {replies}");
-        println!("super like: {:?}", post.poster().super_like());
+        println!("super like: {:?}", comment.poster().super_like());
+        println!("is_top: {}", comment.is_top().await.unwrap());
 
-        for reply in post.replies().await? {
+        for reply in comment.replies().await? {
             println!("\tusername: {}", reply.poster().username());
             println!("\tcontents: {}", reply.body().contents());
             println!("\tis spoiler: {}", reply.body().is_spoiler());
@@ -52,44 +38,8 @@ async fn main() -> Result<(), Error> {
             println!();
         }
 
-        if client.has_session() {
-            post.upvote().await?;
-            post.downvote().await?;
-            post.unvote().await?;
-
-            // If has valid session and user has moderating permission(is the creator)
-            match post.poster().block().await {
-                Ok(()) => {}
-                Err(BlockUserError::NotCreator) => eprintln!("No moderating permissions!"),
-                Err(BlockUserError::BlockSelf) => eprintln!("Cannot block self!"),
-                Err(err) => eprintln!("{err}"),
-            }
-
-            post.reply("REPLY", true).await?;
-
-            // post.delete().await?;
-        }
-
         println!();
     }
-
-    // If memory constraints are an issue, then the previous `posts` can become problematic as it retrieves and stores
-    // all posts in memory before returning them to operate on. For this usecase, `posts_for_each` is provided but there
-    // are limitations:
-    // - Cannot guarantee to be duplicate free
-    // - Publish order is not guaranteed
-
-    println!("`for_each`:");
-    episode
-        .posts_for_each(async |post| {
-            // Simulating async io.
-            let mut stdout = tokio::io::stdout();
-            let post = format!("{post:#?}");
-            if let Err(err) = stdout.write_all(post.as_bytes()).await {
-                eprintln!("Error writing to stdout: {err}");
-            }
-        })
-        .await?;
 
     return Ok(());
 }

--- a/src/platform/webtoons/client/api/posts.rs
+++ b/src/platform/webtoons/client/api/posts.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::{
     platform::webtoons::{
         error::PostsError,
@@ -15,7 +17,6 @@ use chrono::DateTime;
 use serde::Deserialize;
 use std::{str::FromStr, sync::Arc};
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct RawPostResponse {
     pub result: RawResult,
@@ -23,7 +24,6 @@ pub struct RawPostResponse {
     pub status: String,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RawResult {
@@ -42,7 +42,6 @@ pub struct RawResult {
     pub tops: Vec<RawPost>,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Pagination {
@@ -51,7 +50,6 @@ pub struct Pagination {
     pub prev: Option<Id>,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RawPost {
@@ -87,7 +85,6 @@ pub struct RawPost {
     pub updated_at: i64,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatedBy {
@@ -107,7 +104,6 @@ pub struct CreatedBy {
     pub status: String,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Reactions {
@@ -116,7 +112,6 @@ pub struct Reactions {
     pub reaction_id: String,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Emotions {
@@ -125,7 +120,6 @@ pub struct Emotions {
     pub reacted: bool,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BodyFormat {
@@ -138,7 +132,6 @@ pub struct BodyFormat {
 #[serde(rename_all = "camelCase")]
 pub struct ProfileImage {}
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Restriction {
@@ -147,7 +140,6 @@ pub struct Restriction {
     pub is_write_post_restricted: bool,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SectionGroup {
@@ -155,7 +147,6 @@ pub struct SectionGroup {
     pub total_count: u64,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
@@ -190,7 +181,6 @@ pub enum Section {
     },
 }
 
-#[allow(unused)]
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GiphyData {
@@ -200,7 +190,6 @@ pub struct GiphyData {
     // thumbnail: unimplemented!(),
 }
 
-#[allow(unused)]
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct StickerData {
@@ -211,7 +200,6 @@ pub struct StickerData {
     height: u16,
 }
 
-#[allow(unused)]
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ContentMetaData {
@@ -221,7 +209,6 @@ pub struct ContentMetaData {
     pub info: ContentInfo,
 }
 
-#[allow(unused)]
 #[derive(Deserialize, Debug)]
 pub struct ContentInfo {
     name: String,
@@ -234,7 +221,7 @@ pub struct Extra {
     pub episode_list_path: String,
 }
 
-#[allow(unused, clippy::struct_field_names)]
+#[allow(clippy::struct_field_names)]
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SuperLikeData {
@@ -243,7 +230,6 @@ pub struct SuperLikeData {
     pub super_like_received_at: i64,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Count {
@@ -264,7 +250,6 @@ pub struct Count {
     pub result: CountResult,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CountResult {

--- a/tests/webtoons_smoke.rs
+++ b/tests/webtoons_smoke.rs
@@ -81,12 +81,11 @@ async fn canvas() {
         let _length = episode.length().await.unwrap();
         let _likes = episode.likes().await.unwrap();
 
-        episode
-            .posts_for_each(async |post| {
-                let _replies = post.replies().await.unwrap();
-            })
-            .await
-            .unwrap();
+        let mut comments = episode.posts();
+
+        while let Some(comment) = comments.next().await.unwrap() {
+            let _replies = comment.replies().await.unwrap();
+        }
     }
 }
 
@@ -171,11 +170,9 @@ async fn originals() {
         let _length = episode.length().await.unwrap();
         let _likes = episode.likes().await.unwrap();
 
-        episode
-            .posts_for_each(async |post| {
-                let _replies = post.replies().await.unwrap();
-            })
-            .await
-            .unwrap();
+        let mut comments = episode.posts();
+        while let Some(comment) = comments.next().await.unwrap() {
+            let _replies = comment.replies().await.unwrap();
+        }
     }
 }


### PR DESCRIPTION
This introduces an extra layer of encapsulation around `Post`. Not all methods on `Post` can be used in all contexts where it is currently returned. To address this, we introduce `Comment` and `Reply` that encapsulated the internal `Post`, only exposing the pertinent methods.

For example, `Comment` doesn't need to expose a `parent_id` as `parent_id` is the same as its `id`, and it only adds confusion in the api, currently addressed as a doc comment. 

Another example is that you can reply to a `Comment`, but not a `Reply`, yet `Post` exposes it where a reply is currently gotten.