### PR TITLE
fix(webtoons/episode): handle images with multple `.` in file name

### DIFF
--- a/src/platform/webtoons/webtoon/episode.rs
+++ b/src/platform/webtoons/webtoon/episode.rs
@@ -1886,7 +1886,7 @@ fn panels(html: &Html, episode: u16) -> Result<Vec<Panel>, Assumption> {
         url.set_host(Some("swebtoon-phinf.pstatic.net"))
             .assumption("`swebtoon-phinf.pstatic.net` should be a valid host")?;
 
-        let ext = match url.path().split('.').nth(1) {
+        let ext = match url.path().split('.').next_back() {
             Some(ext) => ext.to_string(),
             None => assumption!(
                 "`webtoons.com` episode page panel image urls should end in an extension, got: {url}"

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -891,3 +891,13 @@ async fn english_canvas_creator_with_multiple_trailing_dots_is_ok() {
     let creators = webtoon.creators().await.unwrap();
     assert!(creators.len() == 1);
 }
+
+#[tokio::test]
+async fn english_canvas_panel_image_with_multiple_dots_in_ext_is_ok() {
+    let client = Client::new();
+    let webtoon = client.webtoon(460550, Type::Canvas).await.unwrap().unwrap();
+    let episode = webtoon.episode(1).await.unwrap().unwrap();
+    // For when images ended with: `1.7.jpeg`. Make sure to only get the `jpeg` part.
+    let length = episode.length().await.unwrap().unwrap();
+    assert_eq!(7715, length);
+}


### PR DESCRIPTION
Another caught by the smoke test. For images that had, for example, `1.7.jpeg`, the previous logic would get `7` instead of the desired `jepg`. Now use `next_back` to get the last element after splitting on `.`, which should hopefully always be the extension name.