### PR TITLE
fix(webtoons/creator): handle invalid creator profile response

### DIFF
--- a/src/platform/webtoons/client.rs
+++ b/src/platform/webtoons/client.rs
@@ -299,6 +299,7 @@ impl Client {
     ///   supported language. In this case, even though the language is supported, the creator
     ///   does not have a profile page.
     /// - [`CreatorError::PageDisabledByCreator`]: Profile for creator exists, but is disabled.
+    /// - [`CreatorError::InvalidCreatorProfile`]: Profile for creator exists, but for an unknown reason, does not respond with the expected normal homepage: [`example`]
     ///
     /// # Example
     ///
@@ -320,6 +321,7 @@ impl Client {
     /// ```
     ///
     /// [`https://www.webtoons.com/p/community/en/u/w7m5o`]: https://www.webtoons.com/p/community/en/u/w7m5o
+    /// [`example`]: https://www.webtoons.com/p/community/en/u/y87lz
     pub async fn creator(
         &self,
         profile: &str,

--- a/src/platform/webtoons/error.rs
+++ b/src/platform/webtoons/error.rs
@@ -78,6 +78,8 @@ mod _inner {
             UnsupportedLanguage,
             #[display("profile page disabled by creator")]
             PageDisabledByCreator,
+            #[display("invalid creator profile")]
+            InvalidCreatorProfile,
         } || Base || ClientError
 
         WebtoonError := Base || ClientError

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -1,6 +1,7 @@
 use webtoon::platform::webtoons::{
     Client, Language, Type,
     canvas::Sort,
+    error::CreatorError,
     meta::Genre,
     originals::{Schedule, Weekday},
 };
@@ -900,4 +901,15 @@ async fn english_canvas_panel_image_with_multiple_dots_in_ext_is_ok() {
     // For when images ended with: `1.7.jpeg`. Make sure to only get the `jpeg` part.
     let length = episode.length().await.unwrap().unwrap();
     assert_eq!(7715, length);
+}
+
+#[tokio::test]
+async fn english_canvas_creator_invalid_creator_profile() {
+    let client = Client::new();
+    let creator = client.creator("y87lz", Language::En).await;
+
+    match creator {
+        Err(CreatorError::InvalidCreatorProfile) => {}
+        Ok(_) | Err(_) => unreachable!("should return `InvalidCreatorProfile` error: {creator:#?}"),
+    }
 }

--- a/tests/webtoons_smoke.rs
+++ b/tests/webtoons_smoke.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::ignore_without_reason)]
 use webtoon::platform::webtoons::{Client, Language, canvas::Sort, error::CreatorError};
 
 #[tokio::test]
@@ -26,8 +27,20 @@ async fn canvas() {
                 unreachable!("canvas stories can only have one creator: {creators:?}")
             }
             [creator] => {
-                let _has_patreon = creator.has_patreon().await.unwrap();
-                let _id = creator.id().await.unwrap();
+                match creator.has_patreon().await {
+                    Ok(_)
+                    | Err(
+                        CreatorError::InvalidCreatorProfile | CreatorError::PageDisabledByCreator,
+                    ) => {}
+                    Err(err) => panic!("{err}"),
+                }
+                match creator.id().await {
+                    Ok(_)
+                    | Err(
+                        CreatorError::InvalidCreatorProfile | CreatorError::PageDisabledByCreator,
+                    ) => {}
+                    Err(err) => panic!("{err}"),
+                }
             }
         }
 
@@ -100,18 +113,24 @@ async fn originals() {
             creators => {
                 for creator in creators {
                     // TODO: Need to verify that this works for Korean Creators.
-                    let _has_patreon = match creator.has_patreon().await {
-                        Ok(has_patreon) => has_patreon,
-                        Err(CreatorError::PageDisabledByCreator) => None,
+                    match creator.has_patreon().await {
+                        Ok(_)
+                        | Err(
+                            CreatorError::PageDisabledByCreator
+                            | CreatorError::InvalidCreatorProfile,
+                        ) => {}
                         Err(err) => panic!("{err}"),
-                    };
+                    }
 
                     // TODO: Need to verify that this works for Korean Creators.
-                    let _id = match creator.id().await {
-                        Ok(id) => id,
-                        Err(CreatorError::PageDisabledByCreator) => None,
+                    match creator.id().await {
+                        Ok(_)
+                        | Err(
+                            CreatorError::PageDisabledByCreator
+                            | CreatorError::InvalidCreatorProfile,
+                        ) => {}
                         Err(err) => panic!("{err}"),
-                    };
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a URL is invalid, the `webtoons.com` returns a 404. This can happen when the profile doesn't exist. It can also return a 200, but the page has an error message: `Invalid creator profile.`

 It's not exactly clear what the distinction is between these states is, but presumably the 404 means the profile doesn't exist, assuredly, and the 200 + error message means that it does exist, but for an unknown is reporting as invalid.

This was found for: https://www.webtoons.com/en/canvas/the-lonely-vampire/list?title_no=238892

The creator link points to: https://www.webtoons.com/p/community/en/u/y87lz

And this shows the error message page.

This was caught in the smoke test.