### PR TITLE
perf(webtoons/post): cache episode top comments for quicker `is_top`

### DIFF
--- a/src/platform/webtoons/dashboard/episodes.rs
+++ b/src/platform/webtoons/dashboard/episodes.rs
@@ -68,6 +68,7 @@ pub async fn scrape(webtoon: &Webtoon) -> Result<Vec<Episode>, SessionError> {
             thumbnail: Cache::empty(),
             note: Cache::empty(),
             panels: Cache::empty(),
+            top_comments: Cache::empty(),
         });
     }
 
@@ -97,6 +98,7 @@ pub async fn scrape(webtoon: &Webtoon) -> Result<Vec<Episode>, SessionError> {
                 thumbnail: Cache::empty(),
                 note: Cache::empty(),
                 panels: Cache::empty(),
+                top_comments: Cache::empty(),
             });
         }
 

--- a/src/platform/webtoons/webtoon/episode.rs
+++ b/src/platform/webtoons/webtoon/episode.rs
@@ -1,7 +1,7 @@
 //! Module containing things related to an episode on `webtoons.com`.
 
 use super::{Webtoon, post::PinRepresentation};
-use crate::platform::webtoons::webtoon::post::Comments;
+use crate::platform::webtoons::webtoon::post::{Comment, Comments};
 use crate::stdx::cache::{Cache, Store};
 use crate::stdx::error::{Assume, Assumption, assumption};
 use crate::{
@@ -173,6 +173,7 @@ pub struct Episode {
     pub(crate) ad_status: Option<AdStatus>,
     pub(crate) published_status: Option<PublishedStatus>,
     pub(crate) panels: Cache<Vec<Panel>>,
+    pub(crate) top_comments: Cache<[Option<Comment>; 3]>,
 }
 
 impl std::fmt::Debug for Episode {
@@ -189,6 +190,7 @@ impl std::fmt::Debug for Episode {
             ad_status,
             published_status,
             panels,
+            top_comments,
         } = self;
 
         f.debug_struct("Episode")
@@ -202,6 +204,7 @@ impl std::fmt::Debug for Episode {
             .field("ad_status", ad_status)
             .field("published_status", published_status)
             .field("panels", panels)
+            .field("top_comments", top_comments)
             .finish()
     }
 }
@@ -1002,6 +1005,7 @@ impl Episode {
             views: None,
             ad_status: None,
             published_status: None,
+            top_comments: Cache::empty(),
         }
     }
 

--- a/src/platform/webtoons/webtoon/homepage/en.rs
+++ b/src/platform/webtoons/webtoon/homepage/en.rs
@@ -656,6 +656,7 @@ pub(super) fn episode(element: &ElementRef<'_>, webtoon: &Webtoon) -> Result<Epi
         //
         // Same goes for Canvas, impossible to say from just the info on this page.
         ad_status: None,
+        top_comments: Cache::empty(),
     })
 }
 

--- a/src/platform/webtoons/webtoon/rss.rs
+++ b/src/platform/webtoons/webtoon/rss.rs
@@ -108,6 +108,7 @@ pub(super) async fn feed(webtoon: &Webtoon) -> Result<Rss, RssError> {
             panels: Cache::empty(),
             views: None,
             ad_status: None,
+            top_comments: Cache::empty(),
         });
     }
 


### PR DESCRIPTION
With these changes, subsequent calls for `Comment::is_top` now don't need to make a network request. This can significantly speed up iteration.

There is a possibility that in the middle of iteration, and after the first network request to `is_top`, that the comments that were top comments at the time of fetch no longer are after.