### PR TITLE
refactor(webtoons/creator)!: move some network requests out from `Creator` methods

### DIFF
--- a/examples/webtoons/creator.rs
+++ b/examples/webtoons/creator.rs
@@ -9,10 +9,10 @@ async fn main() -> anyhow::Result<()> {
         bail!("no creator exists with given id");
     };
 
-    println!("id: {:?}", creator.id().await?);
+    println!("id: {:?}", creator.id());
     println!("username: {}", creator.username());
-    println!("followers: {:?}", creator.followers().await?);
-    println!("has_patreon: {:?}", creator.has_patreon().await?);
+    println!("followers: {:?}", creator.followers());
+    println!("has_patreon: {:?}", creator.has_patreon());
     println!("webtoons: {:#?}", creator.webtoons().await?);
 
     Ok(())

--- a/src/platform/webtoons/error.rs
+++ b/src/platform/webtoons/error.rs
@@ -67,13 +67,8 @@ mod _inner {
         SearchError := Base || ClientError
 
         CreatorError := {
-            // TODO: This is really only used for `Client::creator`. Currently,
-            // this is also included for all the `Creator` methods, even though
-            // this would never be encountered through them.
             #[display("`webtoons.com` does not support creator profiles for this language")]
             UnsupportedLanguage,
-            #[display("profile page disabled by creator")]
-            PageDisabledByCreator,
             #[display("invalid creator profile")]
             InvalidCreatorProfile,
         } || Base || ClientError

--- a/src/platform/webtoons/webtoon/homepage.rs
+++ b/src/platform/webtoons/webtoon/homepage.rs
@@ -42,7 +42,7 @@ pub async fn scrape(webtoon: &Webtoon) -> Result<Page, WebtoonError> {
     let html = webtoon.client.webtoon_page(webtoon, None).await?;
 
     let page = match webtoon.language {
-        Language::En => en::page(&html, webtoon)?,
+        Language::En => en::page(&html, webtoon).await?,
         Language::Zh => todo!(), // zh::page(&html, webtoon)?,
         Language::Th => todo!(), // th::page(&html, webtoon)?,
         Language::Id => todo!(), // id::page(&html, webtoon)?,

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -42,13 +42,13 @@ async fn english_creator() {
     let profile = creator.profile();
     assert_eq!(Some("JennyToons"), profile);
 
-    let id = creator.id().await.unwrap();
-    assert_eq!(Some("n5z4d"), id.as_deref());
+    let id = creator.id();
+    assert_eq!(Some("n5z4d"), id);
 
-    let followers = creator.followers().await.unwrap();
+    let followers = creator.followers();
     assert!(followers.is_some());
 
-    let has_patreon = creator.has_patreon().await.unwrap();
+    let has_patreon = creator.has_patreon();
     assert_eq!(Some(true), has_patreon);
 
     let webtoons = creator.webtoons().await.unwrap().unwrap();
@@ -303,7 +303,7 @@ async fn english_webtoon_canvas() {
         [creator] => {
             assert_eq!("RoloEdits", creator.username());
             assert_eq!(Some("_nb3nw"), creator.profile());
-            assert!(!creator.has_patreon().await.unwrap().unwrap());
+            assert!(!creator.has_patreon().unwrap());
         }
     }
 
@@ -384,7 +384,7 @@ async fn english_webtoon_original() {
         [creator] => {
             assert_eq!("Sejji", creator.username());
             assert_eq!(Some("08x59"), creator.profile());
-            assert_eq!(Some(true), creator.has_patreon().await.unwrap());
+            assert_eq!(Some(true), creator.has_patreon());
         }
     }
 
@@ -805,5 +805,26 @@ async fn english_canvas_creator_invalid_creator_profile() {
     match creator {
         Err(CreatorError::InvalidCreatorProfile) => {}
         Ok(_) | Err(_) => unreachable!("should return `InvalidCreatorProfile` error: {creator:#?}"),
+    }
+}
+
+#[tokio::test]
+async fn english_original_creator_of_korean_story_should_scrape_fine() {
+    let client = Client::new();
+    let webtoon = client.webtoon(95, Type::Original).await.unwrap().unwrap();
+
+    let title = webtoon.title().await.unwrap();
+    assert_eq!("Tower of God", title);
+
+    let creators = webtoon.creators().await.unwrap();
+
+    if let [creator] = creators.as_slice() {
+        assert_eq!("SIU", creator.username());
+        assert!(creator.profile().is_none());
+        assert!(creator.id().is_none());
+        assert!(creator.followers().is_none());
+        assert!(creator.has_patreon().is_none());
+    } else {
+        unreachable!("should find SIU on Tower of God: {creators:?}");
     }
 }

--- a/tests/webtoons_smoke.rs
+++ b/tests/webtoons_smoke.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::ignore_without_reason)]
-use webtoon::platform::webtoons::{Client, Language, canvas::Sort, error::CreatorError};
+use webtoon::platform::webtoons::{Client, Language, canvas::Sort};
 
 #[tokio::test]
 #[ignore]
@@ -27,20 +27,9 @@ async fn canvas() {
                 unreachable!("canvas stories can only have one creator: {creators:?}")
             }
             [creator] => {
-                match creator.has_patreon().await {
-                    Ok(_)
-                    | Err(
-                        CreatorError::InvalidCreatorProfile | CreatorError::PageDisabledByCreator,
-                    ) => {}
-                    Err(err) => panic!("{err}"),
-                }
-                match creator.id().await {
-                    Ok(_)
-                    | Err(
-                        CreatorError::InvalidCreatorProfile | CreatorError::PageDisabledByCreator,
-                    ) => {}
-                    Err(err) => panic!("{err}"),
-                }
+                _ = creator.id();
+                _ = creator.followers();
+                _ = creator.has_patreon();
             }
         }
 
@@ -111,25 +100,9 @@ async fn originals() {
             [] => unreachable!("every webtoon must have a creator"),
             creators => {
                 for creator in creators {
-                    // TODO: Need to verify that this works for Korean Creators.
-                    match creator.has_patreon().await {
-                        Ok(_)
-                        | Err(
-                            CreatorError::PageDisabledByCreator
-                            | CreatorError::InvalidCreatorProfile,
-                        ) => {}
-                        Err(err) => panic!("{err}"),
-                    }
-
-                    // TODO: Need to verify that this works for Korean Creators.
-                    match creator.id().await {
-                        Ok(_)
-                        | Err(
-                            CreatorError::PageDisabledByCreator
-                            | CreatorError::InvalidCreatorProfile,
-                        ) => {}
-                        Err(err) => panic!("{err}"),
-                    }
+                    _ = creator.id();
+                    _ = creator.followers();
+                    _ = creator.has_patreon();
                 }
             }
         }


### PR DESCRIPTION
For `Client:creator` we already fetched the creator page, but we also had to try to get the same page in the methods when it might not be needed. This was done to support when creators are gotten via `Webtoon::creators`. Instead, we can also move the initial page scraping to when the creators are gotten from this way. This moves the async calls, but this path already had async to begin with. Now, we can present simple sync methods on `Creator`, which cannot fail. This can simplify the API a lot for maintainability, like documentation, and end users, who need to handle errors in less spots.