### PR TITLE
refactor(webtoons/comment)!: pre-cache top comments

### DIFF
--- a/examples/webtoons/posts.rs
+++ b/examples/webtoons/posts.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Error> {
         let replies = comment.reply_count();
         println!("replies: {replies}");
         println!("super like: {:?}", comment.poster().super_like());
-        println!("is_top: {}", comment.is_top().await.unwrap());
+        println!("is_top: {}", comment.is_top());
 
         for reply in comment.replies().await? {
             println!("\tusername: {}", reply.poster().username());

--- a/src/platform/webtoons/client/api/posts.rs
+++ b/src/platform/webtoons/client/api/posts.rs
@@ -415,7 +415,6 @@ impl TryFrom<(&Episode, RawPost)> for Post {
             upvotes,
             downvotes,
             replies: post.child_post_count,
-            is_top: post.is_pinned,
             is_deleted,
             posted,
             poster: Poster {


### PR DESCRIPTION
Now cache the top comments when doing the initial comments iterating. This allows to make `is_top` sync and infallible. This is inline with other changes we are making to reduce failure to smaller points and simplify the API.