### PR TITLE
refactor(webtoons/creator): trim spaces in creator name

### DIFF
--- a/src/platform/webtoons/webtoon/homepage/en.rs
+++ b/src/platform/webtoons/webtoon/homepage/en.rs
@@ -163,7 +163,7 @@ pub(super) async fn creators(
             let username = selected
                 .text()
                 .next()
-                .map(|str| str.trim())
+                .map(|this| this.trim())
                 .assumption("`webtoons.com` creator text element should always be populated")?;
 
             let creator = match creator::homepage(Language::En, profile, client).await {
@@ -176,7 +176,7 @@ pub(super) async fn creators(
                     client: client.clone(),
                     id: Some(id),
                     profile: Some(profile.into()),
-                    username,
+                    username: username.trim().to_string(),
                     language: Language::En,
                     followers: Some(followers),
                     has_patreon: Some(has_patreon),
@@ -261,7 +261,7 @@ pub(super) async fn creators(
                 // with multiple creators, there are (for some reason) tabs in the text:
                 //     - `" SUMPUL , HereLee , Alphatart ... "`: https://www.webtoons.com/en/fantasy/the-remarried-empress/list?title_no=2135
                 // This should allow commas in usernames, while still filtering away the standalone `,` separator.
-                'username: for username in text
+                for username in text
                     .trim()
                     .split('\t')
                     .map(|str| str.trim())
@@ -278,7 +278,7 @@ pub(super) async fn creators(
                     // to check if they already exist in the list, continuing to
                     // the next text block if so.
                     if creators.iter().any(|creator| creator.username == username) {
-                        continue 'username;
+                        continue;
                     }
 
                     creators.push(Creator {

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -842,3 +842,23 @@ async fn english_canvas_creator_should_not_have_html_encoded_text() {
         unreachable!("should find SIU on Tower of God: {creators:?}");
     }
 }
+
+#[tokio::test]
+async fn english_canvas_creator_names_can_have_spaces_at_end() {
+    let client = Client::new();
+    let webtoon = client.webtoon(796674, Type::Canvas).await.unwrap().unwrap();
+
+    let creators = webtoon.creators().await.unwrap();
+
+    if let [creator] = creators.as_slice() {
+        // FIX: This should have a space at the end, but due to the cleaning
+        // of the creators names (because `webtoons.com` makes a mess of the names)
+        // we just trim.
+        //
+        // This is not correct! The names should be maintained, but there isn't
+        // really a good way to achieve this for now.
+        assert_eq!("illustraboxstudios", creator.username());
+    } else {
+        unreachable!("should find creator: {creators:?}");
+    }
+}


### PR DESCRIPTION
This was found by the smoke test. 

For creators like: https://www.webtoons.com/en/canvas/aggro/list?title_no=796674

There can be spaces at the end of the name (and in theory the beginning). The correct way to handle this would be to preserve them, but due to how the css, where the names can come up multiple times, and with the names sometimes having butchered formatting, for now the choice is made to just trim all surrounding spaces. Any more and the way to parse isn't exactly clear cut. There are a lot of things to try to handle at once, and this seems the worst option, though not fully correct. In all, this part of the code is some of the messiest in the entire code base, and has been frustrating to deal with. 

For now this "fixes" an issue of having more creators in the list than intended, but also add a FIX comment to try to address later.