### PR TITLE
refactor(webtoons/creator): handle invalid profiles with a fallback

### DIFF
--- a/src/platform/webtoons/webtoon/homepage/en.rs
+++ b/src/platform/webtoons/webtoon/homepage/en.rs
@@ -181,7 +181,8 @@ pub(super) async fn creators(
                     followers: Some(followers),
                     has_patreon: Some(has_patreon),
                 },
-                Ok(None) => Creator {
+                // Invalid creator profiles can be found for `webtoons.com` links
+                Ok(None) | Err(CreatorError::InvalidCreatorProfile) => Creator {
                     client: client.clone(),
                     id: None,
                     profile: Some(profile.into()),
@@ -198,9 +199,6 @@ pub(super) async fn creators(
                 Err(CreatorError::UnsupportedLanguage) => {
                     assumption!("`Language::En` should be a supported language")
                 }
-                Err(CreatorError::InvalidCreatorProfile) => assumption!(
-                    "creator profiles found on `webtoons.com` Webtoon homepage should be a valid profile"
-                ),
             };
 
             assumption!(

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -800,11 +800,32 @@ async fn english_canvas_panel_image_with_multiple_dots_in_ext_is_ok() {
 #[tokio::test]
 async fn english_canvas_creator_invalid_creator_profile() {
     let client = Client::new();
-    let creator = client.creator("y87lz", Language::En).await;
 
-    match creator {
-        Err(CreatorError::InvalidCreatorProfile) => {}
-        Ok(_) | Err(_) => unreachable!("should return `InvalidCreatorProfile` error: {creator:#?}"),
+    {
+        match client.creator("y87lz", Language::En).await {
+            Err(CreatorError::InvalidCreatorProfile) => {}
+            creator => {
+                unreachable!("should return `InvalidCreatorProfile` error: {creator:#?}")
+            }
+        }
+    }
+
+    {
+        match client.creator("k7yid", Language::En).await {
+            Err(CreatorError::InvalidCreatorProfile) => {}
+            creator => {
+                unreachable!("should return `InvalidCreatorProfile` error: {creator:#?}")
+            }
+        }
+    }
+
+    {
+        match client.creator("m8sw0", Language::En).await {
+            Err(CreatorError::InvalidCreatorProfile) => {}
+            creator => {
+                unreachable!("should return `InvalidCreatorProfile` error: {creator:#?}")
+            }
+        }
     }
 }
 
@@ -860,5 +881,32 @@ async fn english_canvas_creator_names_can_have_spaces_at_end() {
         assert_eq!("illustraboxstudios", creator.username());
     } else {
         unreachable!("should find creator: {creators:?}");
+    }
+}
+
+#[tokio::test]
+async fn english_canvas_creators_have_invalid_profiles_but_should_fallback_and_not_error() {
+    let client = Client::new();
+
+    {
+        let webtoon = client.webtoon(715380, Type::Canvas).await.unwrap().unwrap();
+        let creators = webtoon.creators().await.unwrap();
+
+        if let [creator] = creators.as_slice() {
+            assert_eq!("Gacha R0bin", creator.username());
+        } else {
+            unreachable!("should find creator: {creators:?}");
+        }
+    }
+
+    {
+        let webtoon = client.webtoon(639752, Type::Canvas).await.unwrap().unwrap();
+        let creators = webtoon.creators().await.unwrap();
+
+        if let [creator] = creators.as_slice() {
+            assert_eq!("minutsi-minu", creator.username());
+        } else {
+            unreachable!("should find creator: {creators:?}");
+        }
     }
 }


### PR DESCRIPTION
TODO: Actually cannot handle it this way, as `Creator` methods dont return any errors to indicate an `InvalidProfile`.