### PR TITLE
refactor(webtoons/creator): document profile page can return `None` when community disabled

### DIFF
--- a/src/platform/webtoons/creator.rs
+++ b/src/platform/webtoons/creator.rs
@@ -201,7 +201,7 @@ impl Creator {
     /// - Korean
     /// - Chinese.
     ///
-    /// If the profile page is disabled by the creator, this will also return `None`.
+    /// If the profile page is disabled, this will also return `None`.
     ///
     /// # Example
     ///
@@ -245,7 +245,7 @@ impl Creator {
     ///
     /// This is for creators where there are no profile, either due to being a Korean based creator,
     /// or that the language version of `webtoons.com` does not support profile pages. It also will return `None` if the
-    /// Creator has disabled their creator page.
+    /// creator page is disabled.
     ///
     /// The webtoons returned are only those that are publicly viewable. If there are no viewable webtoons, it will return an empty `Vec`.
     ///
@@ -298,8 +298,8 @@ impl Creator {
 
     /// Returns if creator has a `Patreon` linked to their account.
     ///
-    /// Will return `None` if the language version of the site doesn't support profile pages, or if the Creator has
-    /// disabled their profile page.
+    /// Will return `None` if the language version of the site doesn't support profile pages, or if the profile page is
+    /// disabled.
     ///
     /// **Unsupported Languages**:
     /// - Korean

--- a/tests/webtoons.rs
+++ b/tests/webtoons.rs
@@ -904,10 +904,14 @@ async fn english_canvas_invalid_creator_profile() {
 async fn english_canvas_creator_page_is_disabled_for_community_policy_violation() {
     let client = Client::new();
 
-    match client.creator("_o2pgx6", Language::En).await {
-        Ok(None) => {}
-        _ => unreachable!("Creator profile page should be disabled for community violations"),
+    for profile in ["_dcrhv7", "_pdi0q8", "_o2pgx6"] {
+        match client.creator(profile, Language::En).await {
+            Ok(None) => {}
+            _ => unreachable!("Creator profile page should be disabled for community violations"),
+        }
     }
+
+    // Sanity check for getting the creator page from the webtoon page.
 
     let webtoon = client.webtoon(939253, Type::Canvas).await.unwrap().unwrap();
 


### PR DESCRIPTION
Also added tests that came from the smoke test for other profiles that are disabled.