### PR TITLE
fix: update expected error message for deactivated creator profile

### DIFF
--- a/src/platform/webtoons/creator.rs
+++ b/src/platform/webtoons/creator.rs
@@ -8,7 +8,7 @@ use crate::{
         macros::maybe,
     },
 };
-use assumptions::{Assume, Assumption, assume, assumption};
+use assumptions::{Assume, Assumption, assume, assume_eq, assumption};
 use core::fmt::{self, Debug};
 use futures::future;
 use scraper::{Html, Selector};
@@ -302,8 +302,8 @@ pub(super) async fn homepage(
         return Ok(None);
     };
 
-    if is_invalid(&html) {
-        return Err(CreatorError::InvalidCreatorProfile);
+    if is_deactivated(&html)? {
+        return Err(CreatorError::DeactivatedCreatorProfile);
     }
 
     if is_disabled_for_community_violation(&html) {
@@ -447,24 +447,31 @@ fn has_patreon(html: &Html) -> bool {
 //
 // https://www.webtoons.com/p/community/en/u/y87lz
 #[inline]
-#[must_use]
-fn is_invalid(html: &Html) -> bool {
+fn is_deactivated(html: &Html) -> Result<bool, Assumption> {
+    // Element(<p class="ErrorPage_text__FQYij">) => { Text("Creator has de-activated their profile.") }
+
     let selector = Selector::parse("p") //
         .expect("`p` should be a valid selector");
 
-    // Element(<p class="ErrorPage_text__FQYij">) => { Text("Invalid creator profile.") }
-    html.select(&selector)
-        .find(|element| {
-            element
-                .attr("class")
-                .is_some_and(|class| class.starts_with("ErrorPage_text"))
-        })
-        .is_some_and(|element| {
-            element
-                .text()
-                .next()
-                .is_some_and(|text| text == "Invalid creator profile.")
-        })
+    let Some(element) = html.select(&selector).find(|element| {
+        matches!(element.attr("class"), Some(class) if class.starts_with("ErrorPage_text"))
+    }) else {
+      return Ok(false);
+    };
+
+    let Some(text) = element.text().next() else {
+        assumption!(
+            "if there is an `ErrorPage_text` element on creator profile page, there should always be text: {element:#?}"
+        );
+    };
+
+    assume_eq!(
+        text,
+        "Creator has de-activated their profile.",
+        "`ErrorPage_text` had an unexpected message"
+    );
+
+    Ok(true)
 }
 
 // When a creator page is disabled due to community policy violations, `webtoons.com`

--- a/src/platform/webtoons/error.rs
+++ b/src/platform/webtoons/error.rs
@@ -44,8 +44,8 @@ mod _inner {
         CreatorWebtoonsError := CreatorError || ClientError
 
         CreatorError := {
-            #[display("invalid creator profile")]
-            InvalidCreatorProfile,
+            #[display("deactivated creator profile")]
+            DeactivatedCreatorProfile,
         } || Internal || Network
 
         WebtoonError := Internal || Network

--- a/src/platform/webtoons/webtoon/episode.rs
+++ b/src/platform/webtoons/webtoon/episode.rs
@@ -18,6 +18,7 @@ use scraper::{ElementRef, Html, Selector};
 use std::hash::Hash;
 use url::Url;
 
+#[cfg(feature = "download")]
 use std::debug_assert as ensure;
 
 /// An episode on `webtoons.com`.

--- a/tests/english_webtoons.rs
+++ b/tests/english_webtoons.rs
@@ -595,17 +595,6 @@ async fn english_canvas_panel_image_with_multiple_dots_in_ext_is_ok() {
 }
 
 #[tokio::test]
-async fn english_canvas_creator_invalid_creator_profile() {
-    let client = Client::new();
-    let creator = client.creator("y87lz").await;
-
-    match creator {
-        Err(CreatorError::InvalidCreatorProfile) => {}
-        Ok(_) | Err(_) => unreachable!("should return `InvalidCreatorProfile` error: {creator:#?}"),
-    }
-}
-
-#[tokio::test]
 async fn english_original_creator_of_korean_story_should_scrape_fine() {
     let client = Client::new();
     let webtoon = client.webtoon(95, Type::Original).await.unwrap().unwrap();
@@ -689,9 +678,9 @@ async fn english_canvas_invalid_creator_profile() {
 
     for profile in ["_91ms9c", "y87lz", "k7yid", "m8sw0"] {
         match client.creator(profile).await {
-            Err(CreatorError::InvalidCreatorProfile) => {}
+            Err(CreatorError::DeactivatedCreatorProfile) => {}
             creator => {
-                unreachable!("should return `InvalidCreatorProfile` error: {creator:#?}")
+                unreachable!("should return `DeactivatedCreatorProfile` error: {creator:#?}")
             }
         }
     }


### PR DESCRIPTION
Error message changed to:
<img width="481" height="252" alt="image" src="https://github.com/user-attachments/assets/a334c6b0-5132-4698-ac0e-3a23938ed321" />
